### PR TITLE
Remove unnecessary type cast for collection object 

### DIFF
--- a/app/src/main/java/com/mxt/anitrend/adapter/recycler/index/MediaListAdapter.kt
+++ b/app/src/main/java/com/mxt/anitrend/adapter/recycler/index/MediaListAdapter.kt
@@ -56,7 +56,7 @@ class MediaListAdapter(context: Context?) :
         return object : Filter() {
             override fun performFiltering(constraint: CharSequence): FilterResults {
                 val results = FilterResults()
-                if (CompatUtil.isEmpty(clone as List<MediaList?>)) clone = data
+                if (CompatUtil.isEmpty(clone)) clone = data
 
                 val filter = constraint.toString()
                 if (TextUtils.isEmpty(filter)) {


### PR DESCRIPTION
Casting for the sake of checking if collection is empty is redundant as we do not need to know the type at this point
